### PR TITLE
Include Swagger-UI

### DIFF
--- a/mensa-api/pom.xml
+++ b/mensa-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.5.8</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -24,6 +24,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/mensa-api/src/main/java/com/example/mensaapi/config/SwaggerConfig.java
+++ b/mensa-api/src/main/java/com/example/mensaapi/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.example.mensaapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import java.util.Collections;
+
+@Configuration
+public class SwaggerConfig {
+
+    private ApiInfo apiInfo() {
+        return new ApiInfo("Mensa API - Studentenwerk Würzburg",
+                "API für die Mensen & Cafeterien des Studentenwerks Würzburg. KEINE OFFIZIELLE API DES STUDENTENWERKS!",
+                "1.0",
+                "https://github.com/TimoReusch/studentenwerk-wuerzburg-mensa-api",
+                new Contact("GitHub", "https://github.com/TimoReusch/studentenwerk-wuerzburg-mensa-api", ""),
+                "",
+                "",
+                Collections.emptyList());
+    }
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+}


### PR DESCRIPTION
Spring Boot Version was set to 2.5.8 to make Springfox function properly.

When the server is running, you can now view Swagger-Documentation on [http://localhost:8080/swagger-ui/](http://localhost:8080/swagger-ui/ ) (the trailing slash is mandatory!)

There is also a JSON-Documentation available on http://localhost:8080/v3/api-docs (OpenAPI Version 3) or http://localhost:8080/v2/api-docs (OpenAPI Version 2). SwaggerUI displays v3.